### PR TITLE
Adding gitignore file to ignore macos hidden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
macOs automatically adds hidden files named .DS_Store which cause confusion at the time of commit, so added them as the part of gitignore. This will make the file ignored in future commits.